### PR TITLE
Bug Fix: Component State was always NULL

### DIFF
--- a/resources/views/forms/components/flatpickr.blade.php
+++ b/resources/views/forms/components/flatpickr.blade.php
@@ -32,7 +32,7 @@
     <link rel="stylesheet" id="pickr-theme" type="text/css" href="{{$getThemeAsset()}}">
     <div
         x-data="flatpickrDatepicker({
-{{--                state: $wire.{{ $applyStateBindingModifiers("entangle('{$getStatePath()}')") }},--}}
+                state: $wire.{{ $applyStateBindingModifiers("entangle('{$getStatePath()}')") }},
                 packageConfig: @js($config),
                 attribs: @js($attribs)
             })"
@@ -74,6 +74,7 @@
                         'disabled' => $isDisabled,
                         'id' => $id,
                         'x-ref' => 'picker',
+                        'x-model' => 'state',
                         'inlinePrefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
                         'inlineSuffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
                         'placeholder' => $getPlaceholder(),


### PR DESCRIPTION
The state of the component in PHP was always NULL due to a bug in the configuration of the Alpine.js view.

- Fixes #34
- Fixes #35