### PR TITLE
Fix altInput with `live()` fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
     ],
     "require": {
         "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0"
+        "filament/filament": "^3.0",
+        "illuminate/contracts": "^10.0",
+        "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/resources/views/forms/components/flatpickr.blade.php
+++ b/resources/views/forms/components/flatpickr.blade.php
@@ -47,6 +47,7 @@
         ax-load-src="{{\Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('flatpickr-component',package: \Coolsam\FilamentFlatpickr\FilamentFlatpickr::getPackageName())}}"
     >
         <x-filament::input.wrapper
+            wire:ignore
             :disabled="$isDisabled"
             :inline-prefix="$isPrefixInline"
             :inline-suffix="$isSuffixInline"


### PR DESCRIPTION
This PR fixes #45. When altInput was being used, any livewire updates to the page would result in the visible input box being cleared. 

I think this is because livewire doesn't know about the format required for repopulating the visible input box. Adding `wire:ignore` to the input seems to fix the issue. 